### PR TITLE
Fixed recording status feedback

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -129,7 +129,7 @@ exports.initAPI = function() {
 					audio: audioData(xml.vmix.audio[0]),
 					status: {
 						fadeToBlack: xml.vmix.fadeToBlack[0] === 'True',
-						recording: xml.vmix.recording[0] === 'True',
+						recording: xml.vmix.recording[0] === 'True' || xml.vmix.recording[0]._ === 'True',
 						external: xml.vmix.external[0] === 'True',
 						streaming: xml.vmix.streaming[0] === 'True',
 						playList: xml.vmix.playList[0] === 'True',


### PR DESCRIPTION
Fixed recording status to account for how the XML can be parsed as either a string or an object if additional parameters on the element are present.

Fixes #21 