### PR TITLE
Added poll interval config option and additional values to default instance state

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -11,10 +11,15 @@ vMix runs on Windows 7, Windows 8 and Windows 10 platforms.
 vMix is a complete live video production software solution with features including LIVE mixing, switching, recording and LIVE streaming of SD, full HD and 4K video sources including cameras, video files, DVDs, images, Powerpoint and much much more.
 
 **API Polling Interval**
-The majority of vMix data used by Companion for feedback and variables is retrieved through the vMix REST API, the frequency at which this data is polled can be changed in the instance config. All instances prior to 1.2.6 had a poll interval of 100ms, but from 1.2.6 the default has been changed to 500ms. It is recommended that users who need responsive feedbacks and had no previous issues to lower the interval in the config back to 100ms, and for users with a significantly large number of inputs or running on older hardware to either leave the interval at 500ms, or enter a slower interval should the server be insufficient for the number of inputs.
 
-Default: 500ms
-Minimum: 100ms
+The majority of vMix data used by Companion for feedback and variables is retrieved through the vMix REST API, the frequency at which this data is polled can be changed in the instance config.
+
+All instances prior to 1.2.6 had a poll interval of 100ms, but from 1.2.6 the default has been changed to 250ms. It is recommended that users who need responsive feedbacks and had no previous issues to lower the interval in the config back to 100ms, and for users with a significantly large number of inputs or running on older hardware to either leave the interval at 250ms, or enter a slower interval should the server be insufficient for the number of inputs.
+
+If you experience high vMix CPU usage while this Companion instance is enabled, increase the interval delay value to slow down the API Polling.
+
+Default: 250ms <br />
+Minimum: 100ms <br />
 Set to 0 to disable API Polling.
 
 

--- a/HELP.md
+++ b/HELP.md
@@ -10,6 +10,14 @@ vMix runs on Windows 7, Windows 8 and Windows 10 platforms.
 
 vMix is a complete live video production software solution with features including LIVE mixing, switching, recording and LIVE streaming of SD, full HD and 4K video sources including cameras, video files, DVDs, images, Powerpoint and much much more.
 
+**API Polling Interval**
+The majority of vMix data used by Companion for feedback and variables is retrieved through the vMix REST API, the frequency at which this data is polled can be changed in the instance config. All instances prior to 1.2.6 had a poll interval of 100ms, but from 1.2.6 the default has been changed to 500ms. It is recommended that users who need responsive feedbacks and had no previous issues to lower the interval in the config back to 100ms, and for users with a significantly large number of inputs or running on older hardware to either leave the interval at 500ms, or enter a slower interval should the server be insufficient for the number of inputs.
+
+Default: 500ms
+Minimum: 100ms
+Set to 0 to disable API Polling.
+
+
 **Functions**
 
 Most commonly used vMix commands have been made available as actions to Companion users, as well as feedback which includes Tally for Mixes 1 to 4, Audio muting, solo, and routing, time remaining countdown for video inputs, title input feedback, and more.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Go over to [vMix](https://www.vmix.com/) to learn more about the software.
 
 **API Poll Interval**
 
-The majority of vMix data used by Companion for feedback and variables is retrieved through the vMix REST API, the frequency at which this data is polled can be changed in the instance config. All instances prior to 1.2.6 had a poll interval of 100ms, but from 1.2.6 the default has been changed to 500ms. It is recommended that users who need responsive feedbacks and had no previous issues to lower the interval in the config back to 100ms, and for users with a significantly large number of inputs or running on older hardware to either leave the interval at 500ms, or enter a slower interval should the server be insufficient for the number of inputs.
+The majority of vMix data used by Companion for feedback and variables is retrieved through the vMix REST API, the frequency at which this data is polled can be changed in the instance config. All instances prior to 1.2.6 had a poll interval of 100ms, but from 1.2.6 the default has been changed to 250ms. It is recommended that users who need responsive feedbacks and had no previous issues to lower the interval in the config back to 100ms, and for users with a significantly large number of inputs or running on older hardware to either leave the interval at 250ms, or enter a slower interval should the server be insufficient for the number of inputs.
 
 **Using Custom Commands/Shortcodes**
 
@@ -80,4 +80,4 @@ and if there is more than one parameter use "&" as a separator between them like
 **v1.2.6**
 * Added default state values to prevent crashing when feedbacks are checked before the API is polled
 * Added API Polling interval config option
-* Increased default API poll interval from 100ms to 500ms.
+* Increased default API poll interval from 100ms to 250ms.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Provides essential control over StudioCoast Vmix, for more info look in HELP.md
 Go over to [vMix](https://www.vmix.com/) to learn more about the software.
 
+**API Poll Interval**
+
+The majority of vMix data used by Companion for feedback and variables is retrieved through the vMix REST API, the frequency at which this data is polled can be changed in the instance config. All instances prior to 1.2.6 had a poll interval of 100ms, but from 1.2.6 the default has been changed to 500ms. It is recommended that users who need responsive feedbacks and had no previous issues to lower the interval in the config back to 100ms, and for users with a significantly large number of inputs or running on older hardware to either leave the interval at 500ms, or enter a slower interval should the server be insufficient for the number of inputs.
+
 **Using Custom Commands/Shortcodes**
 
 When usin vMix shortcodes, please follow this syntax/layout, with space before the first value:
@@ -72,3 +76,8 @@ and if there is more than one parameter use "&" as a separator between them like
 * Added Varibles that lists the ShortTitle of an imput
 * Added Varibles that lists the full title on "list" inputs 
 * Updated Audio presets with the new feedbacks
+
+**v1.2.6**
+* Added default state values to prevent crashing when feedbacks are checked before the API is polled
+* Added API Polling interval config option
+* Increased default API poll interval from 100ms to 500ms.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "studiocoast-vmix",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/src/api.js
+++ b/src/api.js
@@ -289,7 +289,7 @@ exports.initAPI = function () {
 		clearInterval(this.pollAPI);
 	}
 
-	if (this.config.apiPollInterval !== 0) {
+	if (this.config.apiPollInterval != 0) {
 		this.pollAPI = setInterval(getStatus, this.config.apiPollInterval < 100 ? 100 : this.config.apiPollInterval);
 	}
 };

--- a/src/api.js
+++ b/src/api.js
@@ -2,7 +2,7 @@ const got = require('got');
 const xml2js = require('xml2js');
 const _ = require('lodash');
 
-exports.initAPI = function() {
+exports.initAPI = function () {
 	const parseXML = body => {
 		xml2js.parseString(body, (err, xml) => {
 			if (err) {
@@ -92,7 +92,7 @@ exports.initAPI = function() {
 
 					return data;
 				};
-					
+
 
 				const overlayData = overlay => {
 					const data = {
@@ -236,7 +236,7 @@ exports.initAPI = function() {
 					if (input.type === 'VideoList') {
 						// // Remove symbols other than - _ . from the input title
 						let inputTitle = input.title.replace(/[^a-z0-9-_.]+/gi, '');
-						this.setVariable(`input_${input.number}_name`, inputTitle);						
+						this.setVariable(`input_${input.number}_name`, inputTitle);
 					} else {
 						// Remove symbols other than - _ . from the input title
 						let inputName = input.shortTitle.replace(/[^a-z0-9-_.]+/gi, '');
@@ -285,5 +285,11 @@ exports.initAPI = function() {
 			});
 	};
 
-	this.pollAPI = setInterval(getStatus, 100);
+	if (this.pollAPI) {
+		clearInterval(this.pollAPI);
+	}
+
+	if (this.config.apiPollInterval !== 0) {
+		this.pollAPI = setInterval(getStatus, this.config.apiPollInterval);
+	}
 };

--- a/src/api.js
+++ b/src/api.js
@@ -290,6 +290,6 @@ exports.initAPI = function () {
 	}
 
 	if (this.config.apiPollInterval !== 0) {
-		this.pollAPI = setInterval(getStatus, this.config.apiPollInterval);
+		this.pollAPI = setInterval(getStatus, this.config.apiPollInterval < 100 ? 100 : this.config.apiPollInterval);
 	}
 };

--- a/src/config.js
+++ b/src/config.js
@@ -27,10 +27,20 @@ exports.getConfigFields = function () {
 		{
 			type: 'textinput',
 			id: 'apiPollInterval',
-			label: 'API Polling interval (ms) (default: 500, min: 100, 0 for disabled) - See the Help section for details.',
+			label: 'API Polling interval (ms) (default: 250, min: 100, 0 for disabled)',
 			width: 12,
 			default: 500,
 			regex: this.REGEX_NUMBER
-		}
+		},
+		{
+      type: 'text',
+      id: 'apiPollInfo',
+      width: 12,
+      label: 'API Poll Interval warning',
+      value:
+        'Adjusting the API Polling Interval can impact performance. <br />' +
+        'A lower invterval allows for more responsive feedback, but may impact CPU usage. <br />' +
+        'See the help section for more details.' 
+    }
 	];
 };

--- a/src/config.js
+++ b/src/config.js
@@ -27,9 +27,9 @@ exports.getConfigFields = function () {
 		{
 			type: 'textinput',
 			id: 'apiPollInterval',
-			label: 'API Polling interval (ms) (default: 100, 0 for disabled)',
-			width: 6,
-			default: 100,
+			label: 'API Polling interval (ms) (default: 500, min: 100, 0 for disabled) - See the Help section for details.',
+			width: 12,
+			default: 500,
 			regex: this.REGEX_NUMBER
 		}
 	];

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-exports.getConfigFields = function() {
+exports.getConfigFields = function () {
 	return [
 		{
 			type: 'textinput',
@@ -23,6 +23,14 @@ exports.getConfigFields = function() {
 			width: 3,
 			default: 8099,
 			regex: this.REGEX_PORT
+		},
+		{
+			type: 'textinput',
+			id: 'apiPollInterval',
+			label: 'API Polling interval (ms) (default: 100, 0 for disabled)',
+			width: 6,
+			default: 100,
+			regex: this.REGEX_NUMBER
 		}
 	];
 };

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ class VMixInstance extends instance_skel {
 		this.config.host = this.config.host || '127.0.0.1';
 		this.config.httpPort = this.config.httpPort || 8088;
 		this.config.tcpPort = this.config.tcpPort || 8099;
+		this.config.apiPollInterval = this.config.apiPollInterval !== undefined ? this.config.apiPollInterval : 100;
 		this.updateVariableDefinitions = updateVariableDefinitions;
 	}
 
@@ -57,6 +58,7 @@ class VMixInstance extends instance_skel {
 		this.config = config;
 		this.init_tcp();
 		this.init_feedbacks();
+		initAPI.bind(this)();
 		initPresets.bind(this)();
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class VMixInstance extends instance_skel {
 		this.config.host = this.config.host || '127.0.0.1';
 		this.config.httpPort = this.config.httpPort || 8088;
 		this.config.tcpPort = this.config.tcpPort || 8099;
-		this.config.apiPollInterval = this.config.apiPollInterval !== undefined ? this.config.apiPollInterval : 100;
+		this.config.apiPollInterval = this.config.apiPollInterval !== undefined ? this.config.apiPollInterval : 500;
 		this.updateVariableDefinitions = updateVariableDefinitions;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class VMixInstance extends instance_skel {
 		this.config.host = this.config.host || '127.0.0.1';
 		this.config.httpPort = this.config.httpPort || 8088;
 		this.config.tcpPort = this.config.tcpPort || 8099;
-		this.config.apiPollInterval = this.config.apiPollInterval !== undefined ? this.config.apiPollInterval : 500;
+		this.config.apiPollInterval = this.config.apiPollInterval !== undefined ? this.config.apiPollInterval : 250;
 		this.updateVariableDefinitions = updateVariableDefinitions;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,12 +27,46 @@ class VMixInstance extends instance_skel {
 			preset: '',
 			audio: [],
 			inputs: [],
+			overlays: [
+				{ number: '1', preview: false },
+				{ number: '2', preview: false },
+				{ number: '3', preview: false },
+				{ number: '4', preview: false },
+				{ number: '5', preview: false },
+				{ number: '6', preview: false },
+			],
+			transition: [
+				{ number: '1', effect: 'fade', duration: '1000' },
+				{ number: '2', effect: 'fade', duration: '1000' },
+				{ number: '3', effect: 'fade', duration: '1000' },
+				{ number: '4', effect: 'fade', duration: '1000' },
+			],
 			mix: [
 				{ id: 1, active: false, preview: 0, program: 0 },
 				{ id: 2, active: false, preview: 0, program: 0 },
 				{ id: 3, active: false, preview: 0, program: 0 },
 				{ id: 4, active: false, preview: 0, program: 0 }
-			]
+			],
+			audio: [
+				{ volume: '100', muted: 'False', meterF1: '0', meterF2: '0', headphonesVolume: '100', bus: 'master' }
+			],
+			status: {
+				fadeToBlack: false,
+				recording: false,
+				external: false,
+				streaming: false,
+				stream: [false, false, false],
+				playList: false,
+				multiCorder: false,
+				fullscreen: false,
+			},
+			replay: {
+				recording: false,
+				live: false,
+				events: '1',
+				cameraA: '0',
+				cameraB: '0'
+			}
 		};
 
 		this.config.host = this.config.host || '127.0.0.1';

--- a/src/tcp.js
+++ b/src/tcp.js
@@ -22,7 +22,6 @@ exports.init = function() {
 		this.socket.on('connect', () => {
 			this.status(this.STATE_OK);
 			this.debug('Connected');
-			this.socket.send('SUBSCRIBE TALLY\r\n');
 		});
 	}
 };


### PR DESCRIPTION
Added config option to allow for adjustment of API polling interval, default is set to 100ms (the current interval), with a value of 0 disabling polling of the HTTP API.
Resolves #37

Additional values for the default instance state should resolve these issues, where it was possible for data.status to be undefined if feedback attempted to access that value prior to the API being polled.
Resolves #29 
Resolves #31
Resolves #36