### PR TITLE
New API Polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,8 @@ and if there is more than one parameter use "&" as a separator between them like
 **v1.2.7**
 * Added ReplayPlaySelectedEventToOutput and ReplayPlayEventsByIDToOutput to the list of suported functions, with included presets.
 * Added SetTransitionEffect and SetTransitionDuration to the list of actions, with presets.
+
+**v1.2.8**
+* Changed API Polling from HTTP to the TCP connection
+* Removed HTTP Port, Username, and Password, config fields
+* Removed dependency `got`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "studiocoast-vmix",
-	"version": "1.2.7",
+	"version": "1.2.8",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 	],
 	"license": "MIT",
 	"dependencies": {
-		"got": "^6.7.1",
 		"lodash": "^4.17.19",
 		"xml2js": "^0.4.22"
 	}

--- a/src/api.js
+++ b/src/api.js
@@ -138,7 +138,7 @@ exports.parseAPI = function (body) {
 				version: xml.vmix.version[0],
 				edition: xml.vmix.edition[0],
 				preset: xml.vmix.preset ? xml.vmix.preset[0] : '',
-				inputs: xml.vmix.inputs[0].input.map(inputData),
+				inputs: xml.vmix.inputs[0] !== '' ? xml.vmix.inputs[0].input.map(inputData) : [],
 				overlays: xml.vmix.overlays[0].overlay.map(overlayData),
 				transition: xml.vmix.transitions[0].transition.map(transition => transition.$),
 				mix: [

--- a/src/api.js
+++ b/src/api.js
@@ -1,305 +1,273 @@
-const got = require('got');
 const xml2js = require('xml2js');
 const _ = require('lodash');
 
-exports.initAPI = function () {
-	const parseXML = body => {
-		xml2js.parseString(body, (err, xml) => {
-			if (err) {
-				this.debug('info', JSON.stringify(err));
-				this.data.connected = false;
-				this.checkFeedbacks('status');
-			} else {
-				const getMix = number => {
-					const mix = {
-						number,
-						active: false,
-						preview: null,
-						program: null
-					};
-
-					if (xml.vmix.mix) {
-						const data = xml.vmix.mix.find(element => element.$.number == number);
-						if (data) {
-							mix.active = true;
-							mix.preview = parseInt(data.preview, 10);
-							mix.program = parseInt(data.active, 10);
-						}
-					}
-
-					return mix;
+exports.parseAPI = function (body) {
+	xml2js.parseString(body, (err, xml) => {
+		if (err) {
+			this.debug('info', JSON.stringify(err));
+			this.data.connected = false;
+			this.checkFeedbacks('status');
+		} else {
+			const getMix = number => {
+				const mix = {
+					number,
+					active: false,
+					preview: null,
+					program: null
 				};
 
-				const inputData = input => {
-					const data = { ...input.$ };
-
-					if (input.text) {
-						data.text = input.text.map(text => ({
-							index: text.$.index,
-							name: text.$.name,
-							value: text._
-						}));
+				if (xml.vmix.mix) {
+					const data = xml.vmix.mix.find(element => element.$.number == number);
+					if (data) {
+						mix.active = true;
+						mix.preview = parseInt(data.preview, 10);
+						mix.program = parseInt(data.active, 10);
 					}
+				}
 
-					if (input.list) {
-						if (input.list.length > 0) {
-							data.list = input.list[0].$;
-						}
-						else {
+				return mix;
+			};
 
-							data.list = input.list[0].item.map((item, index) => {
-								const location = typeof item === 'string' ? item : item._;
-								return {
-									index,
-									location,
-									filename: location.split('\\')[location.split('\\').length - 1],
-									selected: item.$ && item.$.selected && item.$.selected === 'true'
-								};
-							});
-						}
+			const inputData = input => {
+				const data = { ...input.$ };
+
+				if (input.text) {
+					data.text = input.text.map(text => ({
+						index: text.$.index,
+						name: text.$.name,
+						value: text._
+					}));
+				}
+
+				if (input.list) {
+					if (input.list.length > 0) {
+						data.list = input.list[0].$;
 					}
+					else {
 
-					if (input.position) {
-						data.position = input.position[0].$;
-					}
-
-					if (input.meterF1) {
-						data.meterF1 = input.meterF1[0].$;
-					}
-
-					if (input.meterF2) {
-						data.meterF2 = input.meterF2[0].$;
-					}
-
-					if (input.overlay) {
-						data.overlay = input.overlay.map(item => {
-							const overlay = {
-								index: item.$.index,
-								key: item.$.key
+						data.list = input.list[0].item.map((item, index) => {
+							const location = typeof item === 'string' ? item : item._;
+							return {
+								index,
+								location,
+								filename: location.split('\\')[location.split('\\').length - 1],
+								selected: item.$ && item.$.selected && item.$.selected === 'true'
 							};
-
-							if (item.position) {
-								item.position = item.position.$;
-							}
-
-							return overlay;
 						});
 					}
+				}
 
-					if (input.replay) {
-						data.replay = input.replay[0].$;
-					}
+				if (input.position) {
+					data.position = input.position[0].$;
+				}
 
-					return data;
-				};
+				if (input.meterF1) {
+					data.meterF1 = input.meterF1[0].$;
+				}
 
+				if (input.meterF2) {
+					data.meterF2 = input.meterF2[0].$;
+				}
 
-				const overlayData = overlay => {
-					const data = {
-						number: overlay.$.number,
-						preview: false
-					};
+				if (input.overlay) {
+					data.overlay = input.overlay.map(item => {
+						const overlay = {
+							index: item.$.index,
+							key: item.$.key
+						};
 
-					if (overlay._) {
-						data.input = overlay._;
-					}
-
-					if (overlay.$.preview) {
-						data.preview = true;
-					}
-
-					return data;
-				};
-
-				const audioData = audio => {
-					const data = [];
-
-					Object.keys(audio).forEach(key => {
-						audio[key][0].$.bus = key;
-						data.push(audio[key][0].$);
-					});
-
-					data.forEach(output => {
-						const busID = output.bus === 'master' ? 'master' : output.bus.substr(3);
-						const volume = Math.round(parseFloat(output.volume));
-
-						this.setVariable(`bus_volume_${busID}`, volume);
-
-						if (output.bus === 'master') {
-							const headphonesVolume = Math.round(parseFloat(output.headphonesVolume));
-							this.setVariable('bus_volume_headphones', headphonesVolume);
+						if (item.position) {
+							item.position = item.position.$;
 						}
+
+						return overlay;
 					});
+				}
 
-					return data;
-				};
+				if (input.replay) {
+					data.replay = input.replay[0].$;
+				}
 
+				return data;
+			};
+
+
+			const overlayData = overlay => {
 				const data = {
-					connected: true,
-					version: xml.vmix.version[0],
-					edition: xml.vmix.edition[0],
-					preset: xml.vmix.preset ? xml.vmix.preset[0] : '',
-					inputs: xml.vmix.inputs[0].input.map(inputData),
-					overlays: xml.vmix.overlays[0].overlay.map(overlayData),
-					transition: xml.vmix.transitions[0].transition.map(transition => transition.$),
-					mix: [
-						{
-							number: 1,
-							active: true,
-							preview: parseInt(xml.vmix.preview, 10),
-							program: parseInt(xml.vmix.active, 10)
-						},
-						getMix(2),
-						getMix(3),
-						getMix(4)
-					],
-					audio: audioData(xml.vmix.audio[0]),
-					status: {
-						fadeToBlack: xml.vmix.fadeToBlack[0] === 'True',
-						recording: xml.vmix.recording[0] === 'True' || xml.vmix.recording[0]._ === 'True',
-						external: xml.vmix.external[0] === 'True',
-						streaming: xml.vmix.streaming[0] === 'True' || xml.vmix.streaming[0]._ === 'True',
-						stream: [false, false, false],
-						playList: xml.vmix.playList[0] === 'True',
-						multiCorder: xml.vmix.multiCorder[0] === 'True',
-						fullscreen: xml.vmix.fullscreen[0] === 'True'
-					},
-					replay: {
-						recording: false,
-						live: false,
-						events: '1',
-						cameraA: '0',
-						cameraB: '0'
-					}
+					number: overlay.$.number,
+					preview: false
 				};
 
-				// Update stream Status
-				if (xml.vmix.streaming[0].$) {
-					data.status.stream[0] = xml.vmix.streaming[0].$.channel1 === 'True';
-					data.status.stream[1] = xml.vmix.streaming[0].$.channel2 === 'True';
-					data.status.stream[2] = xml.vmix.streaming[0].$.channel3 === 'True';
+				if (overlay._) {
+					data.input = overlay._;
 				}
 
-				// Update Replay
-				const replayInput = data.inputs.find(input => input.type === 'Replay');
-				if (replayInput) {
-					data.replay.recording = replayInput.replay.recording === 'True';
-					data.replay.live = replayInput.replay.live === 'True';
-					data.replay.events = replayInput.replay.events;
-					data.replay.cameraA = replayInput.replay.cameraA;
-					data.replay.cameraB = replayInput.replay.cameraB;
+				if (overlay.$.preview) {
+					data.preview = true;
 				}
 
-				// Check for changes to update feedbacks
-				const changes = new Set([]);
-				const inputCheck = data.inputs.map(input => input.key).join('') !== this.data.inputs.map(input => input.key).join('');
+				return data;
+			};
 
-				// Check mix 1 to 4
-				if (!_.isEqual(data.mix, this.data.mix) || inputCheck) {
-					changes.add('inputPreview');
-					changes.add('inputLive');
-				}
+			const audioData = audio => {
+				const data = [];
 
-				// Check overlays
-				if (!_.isEqual(data.overlays, this.data.overlays) || inputCheck) {
-					changes.add('overlayStatus');
-				}
+				Object.keys(audio).forEach(key => {
+					audio[key][0].$.bus = key;
+					data.push(audio[key][0].$);
+				});
 
-				// Check for input changes
-				if (!_.isEqual(data.inputs, this.data.inputs) || inputCheck) {
-					changes.add('videoTimer');
-					changes.add('inputMute');
-					changes.add('inputAudio');
-					changes.add('inputSolo');
-					changes.add('inputBusRouting');
-					changes.add('titleLayer');
-					changes.add('inputVolumeLevel');
-					changes.add('liveInputVolume');
-				}
+				data.forEach(output => {
+					const busID = output.bus === 'master' ? 'master' : output.bus.substr(3);
+					const volume = Math.round(parseFloat(output.volume));
 
-				// Check for status changes
-				if (!_.isEqual(data.status, this.data.status) || (data.connected !== this.data.connected) || inputCheck) {
-					changes.add('status');
-				}
+					this.setVariable(`bus_volume_${busID}`, volume);
 
-				// Check Audio status
-				if (!_.isEqual(data.audio, this.data.audio) || inputCheck) {
-					changes.add('busMute');
-					changes.add('busVolumeLevel');
-					changes.add('liveBusVolume');
-				}
-
-				// Update variables
-				data.inputs.forEach(input => {
-					const previousState = this.data.inputs.find(item => item.key === input.key);
-
-					if (input.type === 'VideoList') {
-						// // Remove symbols other than - _ . from the input title
-						let inputTitle = input.title.replace(/[^a-z0-9-_.]+/gi, '');
-						this.setVariable(`input_${input.number}_name`, inputTitle);
-					} else {
-						// Remove symbols other than - _ . from the input title
-						let inputName = input.shortTitle.replace(/[^a-z0-9-_.]+/gi, '');
-						this.setVariable(`input_${input.number}_name`, inputName);
-					}
-
-					// Check input has volume and a different or no previous volume
-					if (input.volume !== undefined && (previousState === undefined || input.volume !== previousState.volume)) {
-						const volume = Math.round(parseFloat(input.volume));
-
-						// Remove symbols other than - _ . from the input title
-						let inputName = input.shortTitle.replace(/[^a-z0-9-_.]+/gi, '');
-						this.setVariable(`input_volume_${inputName}`, volume);
+					if (output.bus === 'master') {
+						const headphonesVolume = Math.round(parseFloat(output.headphonesVolume));
+						this.setVariable('bus_volume_headphones', headphonesVolume);
 					}
 				});
 
-				// Check Replay
-				if (!_.isEqual(data.replay, this.data.replay)) {
-					changes.add('replayStatus');
-					changes.add('replayEvents');
-					changes.add('replayCamera');
+				return data;
+			};
+
+
+			const data = {
+				connected: true,
+				version: xml.vmix.version[0],
+				edition: xml.vmix.edition[0],
+				preset: xml.vmix.preset ? xml.vmix.preset[0] : '',
+				inputs: xml.vmix.inputs[0].input.map(inputData),
+				overlays: xml.vmix.overlays[0].overlay.map(overlayData),
+				transition: xml.vmix.transitions[0].transition.map(transition => transition.$),
+				mix: [
+					{
+						number: 1,
+						active: true,
+						preview: parseInt(xml.vmix.preview, 10),
+						program: parseInt(xml.vmix.active, 10)
+					},
+					getMix(2),
+					getMix(3),
+					getMix(4)
+				],
+				audio: audioData(xml.vmix.audio[0]),
+				status: {
+					fadeToBlack: xml.vmix.fadeToBlack[0] === 'True',
+					recording: xml.vmix.recording[0] === 'True' || xml.vmix.recording[0]._ === 'True',
+					external: xml.vmix.external[0] === 'True',
+					streaming: xml.vmix.streaming[0] === 'True' || xml.vmix.streaming[0]._ === 'True',
+					stream: [false, false, false],
+					playList: xml.vmix.playList[0] === 'True',
+					multiCorder: xml.vmix.multiCorder[0] === 'True',
+					fullscreen: xml.vmix.fullscreen[0] === 'True'
+				},
+				replay: {
+					recording: false,
+					live: false,
+					events: '1',
+					cameraA: '0',
+					cameraB: '0'
 				}
+			};
 
-				data.startup = false;
-				this.data = data;
-
-				changes.forEach(change => this.checkFeedbacks(change));
-
-				// Update variable definitions
-				if (changes.size > 0) {
-					this.updateVariableDefinitions();
-				}
+			// Update stream Status
+			if (xml.vmix.streaming[0].$) {
+				data.status.stream[0] = xml.vmix.streaming[0].$.channel1 === 'True';
+				data.status.stream[1] = xml.vmix.streaming[0].$.channel2 === 'True';
+				data.status.stream[2] = xml.vmix.streaming[0].$.channel3 === 'True';
 			}
-		});
-	};
 
-	const getStatus = () => {
-		const options = {
-			headers: {
-				Authorization: `Basic ${Buffer.from(this.config.username + ':' + this.config.password).toString('base64')}`
+			// Update Replay
+			const replayInput = data.inputs.find(input => input.type === 'Replay');
+			if (replayInput) {
+				data.replay.recording = replayInput.replay.recording === 'True';
+				data.replay.live = replayInput.replay.live === 'True';
+				data.replay.events = replayInput.replay.events;
+				data.replay.cameraA = replayInput.replay.cameraA;
+				data.replay.cameraB = replayInput.replay.cameraB;
 			}
-		};
 
-		got.get(`http://${this.config.host}:${this.config.httpPort || 8088}/api/`, options)
-			.then(res => {
-				if (res.statusCode === 200) {
-					return parseXML(res.body);
+			// Check for changes to update feedbacks
+			const changes = new Set([]);
+			const inputCheck = data.inputs.map(input => input.key).join('') !== this.data.inputs.map(input => input.key).join('');
+
+			// Check mix 1 to 4
+			if (!_.isEqual(data.mix, this.data.mix) || inputCheck) {
+				changes.add('inputPreview');
+				changes.add('inputLive');
+			}
+
+			// Check overlays
+			if (!_.isEqual(data.overlays, this.data.overlays) || inputCheck) {
+				changes.add('overlayStatus');
+			}
+
+			// Check for input changes
+			if (!_.isEqual(data.inputs, this.data.inputs) || inputCheck) {
+				changes.add('videoTimer');
+				changes.add('inputMute');
+				changes.add('inputAudio');
+				changes.add('inputSolo');
+				changes.add('inputBusRouting');
+				changes.add('titleLayer');
+				changes.add('inputVolumeLevel');
+				changes.add('liveInputVolume');
+			}
+
+			// Check for status changes
+			if (!_.isEqual(data.status, this.data.status) || (data.connected !== this.data.connected) || inputCheck) {
+				changes.add('status');
+			}
+
+			// Check Audio status
+			if (!_.isEqual(data.audio, this.data.audio) || inputCheck) {
+				changes.add('busMute');
+				changes.add('busVolumeLevel');
+				changes.add('liveBusVolume');
+			}
+
+			// Update variables
+			data.inputs.forEach(input => {
+				const previousState = this.data.inputs.find(item => item.key === input.key);
+
+				if (input.type === 'VideoList') {
+					// // Remove symbols other than - _ . from the input title
+					let inputTitle = input.title.replace(/[^a-z0-9-_.]+/gi, '');
+					this.setVariable(`input_${input.number}_name`, inputTitle);
+				} else {
+					// Remove symbols other than - _ . from the input title
+					let inputName = input.shortTitle.replace(/[^a-z0-9-_.]+/gi, '');
+					this.setVariable(`input_${input.number}_name`, inputName);
 				}
-			})
-			.catch(err => {
-				if (this.data.connected) {
-					this.data.connected = false;
-					this.checkFeedbacks('status');
+
+				// Check input has volume and a different or no previous volume
+				if (input.volume !== undefined && (previousState === undefined || input.volume !== previousState.volume)) {
+					const volume = Math.round(parseFloat(input.volume));
+
+					// Remove symbols other than - _ . from the input title
+					let inputName = input.shortTitle.replace(/[^a-z0-9-_.]+/gi, '');
+					this.setVariable(`input_volume_${inputName}`, volume);
 				}
-				this.debug('vMix API err:' + JSON.stringify(err));
 			});
-	};
 
-	if (this.pollAPI) {
-		clearInterval(this.pollAPI);
-	}
+			// Check Replay
+			if (!_.isEqual(data.replay, this.data.replay)) {
+				changes.add('replayStatus');
+				changes.add('replayEvents');
+				changes.add('replayCamera');
+			}
 
-	if (this.config.apiPollInterval != 0) {
-		this.pollAPI = setInterval(getStatus, this.config.apiPollInterval < 100 ? 100 : this.config.apiPollInterval);
-	}
+			data.startup = false;
+			this.data = data;
+
+			changes.forEach(change => this.checkFeedbacks(change));
+
+			// Update variable definitions
+			if (changes.size > 0) {
+				this.updateVariableDefinitions();
+			}
+		}
+	});
 };

--- a/src/config.js
+++ b/src/config.js
@@ -21,7 +21,7 @@ exports.getConfigFields = function () {
 			id: 'apiPollInterval',
 			label: 'API Polling interval (ms) (default: 250, min: 100, 0 for disabled)',
 			width: 12,
-			default: 500,
+			default: 250,
 			regex: this.REGEX_NUMBER
 		},
 		{

--- a/src/config.js
+++ b/src/config.js
@@ -10,33 +10,11 @@ exports.getConfigFields = function () {
 		},
 		{
 			type: 'textinput',
-			id: 'httpPort',
-			label: 'HTTP Port (Default: 8088)',
-			width: 3,
-			default: 8088,
-			regex: this.REGEX_PORT
-		},
-		{
-			type: 'textinput',
 			id: 'tcpPort',
 			label: 'TCP Port (Default: 8099)',
 			width: 3,
 			default: 8099,
 			regex: this.REGEX_PORT
-		},		
-		{
-			type: 'textinput',
-			id: 'username',
-			label: 'Username',
-			width: 6,
-			default: ''
-		},
-		{
-			type: 'textinput',
-			id: 'password',
-			label: 'Password',
-			width: 6,
-			default: ''
 		},
 		{
 			type: 'textinput',

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -1,5 +1,3 @@
-const { text } = require("express");
-
 exports.initFeedbacks = function() {
 	const feedbacks = {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,11 +69,8 @@ class VMixInstance extends instance_skel {
 		};
 
 		this.config.host = this.config.host || '127.0.0.1';
-		this.config.httpPort = this.config.httpPort || 8088;
 		this.config.tcpPort = this.config.tcpPort || 8099;
 		this.config.apiPollInterval = this.config.apiPollInterval !== undefined ? this.config.apiPollInterval : 250;
-		this.config.username = '';
-		this.config.password = '';
 		this.updateVariableDefinitions = updateVariableDefinitions;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const instance_skel = require('../../../instance_skel');
 const { executeAction, getActions } = require('./actions');
-const { initAPI } = require('./api');
 const { getConfigFields } = require('./config');
 const { executeFeedback, initFeedbacks } = require('./feedback');
 const { initPresets } = require('./presets');
@@ -83,7 +82,6 @@ class VMixInstance extends instance_skel {
 		this.actions();
 		this.init_tcp();
 		this.init_feedbacks();
-		initAPI.bind(this)();
 		initPresets.bind(this)();
 		this.updateVariableDefinitions();
 	}
@@ -94,7 +92,6 @@ class VMixInstance extends instance_skel {
 		this.config = config;
 		this.init_tcp();
 		this.init_feedbacks();
-		initAPI.bind(this)();
 		initPresets.bind(this)();
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,101 +2,15 @@
 # yarn lockfile v1
 
 
-capture-stack-trace@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
-  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
-
-create-error-class@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
-  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
-  dependencies:
-    capture-stack-trace "^1.0.0"
-
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
-
-got@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
-  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
-  dependencies:
-    create-error-class "^3.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    is-redirect "^1.0.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    safe-buffer "^5.0.1"
-    timed-out "^4.0.0"
-    unzip-response "^2.0.1"
-    url-parse-lax "^1.0.0"
-
-is-redirect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
-  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
-
-is-retry-allowed@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
-  integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
-
-is-stream@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-
 lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-  
-lowercase-keys@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
-
-prepend-http@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
-  integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
-
-safe-buffer@^5.0.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-timed-out@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
-  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
-unzip-response@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
-  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
-
-url-parse-lax@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
-  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
-  dependencies:
-    prepend-http "^1.0.1"
 
 xml2js@^0.4.22:
   version "0.4.23"


### PR DESCRIPTION
Changed polling from the vMix HTTP REST API to the TCP connection that has previously been used just for sending commands. Performance within Companion is unchanged, but this should help combat the memory leaks in vMix. As HTTP requests are no longer required, the `got` library has been removed as a dependency, along with config fields for it.

Default API Poll time is unchanged, but anyone running vMix 23.0.0.66 or higher may be able to reduce the interval now that they have fixed their memory leaks which will result in faster feedback.

Potential issues:
The move to TCP socket for both feedback and commands means that this will be a breaking change for anyone who uses this module where a firewall blocks that TCP connection. I've asked on Companion Slack, and both broadcast and video engineering discords, and have no encountered anyone that this would impact. I don't expect anyone to actually be in this situation, as that would mean they would previously could see feedback but couldn't use any actions as those actions would have been blocked by the firewall too.

Resolves #48