### PR TITLE
fixed erroneous mix option on presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,6 @@ and if there is more than one parameter use "&" as a separator between them like
 * Changed API Polling from HTTP to the TCP connection
 * Removed HTTP Port, Username, and Password, config fields
 * Removed dependency `got`
+
+**v1.2.9**
+* Fixed a bug with preset send input to program buttons which would use `Cut` instead of `CutDirect`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "studiocoast-vmix",
-	"version": "1.2.8",
+	"version": "1.2.9",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/src/presets.js
+++ b/src/presets.js
@@ -19,24 +19,24 @@ exports.initPresets = function() {
 
 	// Mix 1
 	const mix1PreviewProgram = [
-		{ id: 'PreviewInput', mix: '0', input: '1', label: 'PRV 1', size: '24' },
-		{ id: 'PreviewInput', mix: '0', input: '2', label: 'PRV 2', size: '24' },
-		{ id: 'PreviewInput', mix: '0', input: '3', label: 'PRV 3', size: '24' },
-		{ id: 'PreviewInput', mix: '0', input: '4', label: 'PRV 4', size: '24' },
-		{ id: 'PreviewInput', mix: '0', input: '5', label: 'PRV 5', size: '24' },
-		{ id: 'PreviewInput', mix: '0', input: '6', label: 'PRV 6', size: '24' },
-		{ id: 'PreviewInput', mix: '0', input: '7', label: 'PRV 7', size: '24' },
-		{ id: 'PreviewInput', mix: '0', input: '8', label: 'PRV 8', size: '24' },
-		{ id: 'programCut', mix: '0', input: '1', label: 'PRGM 1', size: '24' },
-		{ id: 'programCut', mix: '0', input: '2', label: 'PRGM 2', size: '24' },
-		{ id: 'programCut', mix: '0', input: '3', label: 'PRGM 3', size: '24' },
-		{ id: 'programCut', mix: '0', input: '4', label: 'PRGM 4', size: '24' },
-		{ id: 'programCut', mix: '0', input: '5', label: 'PRGM 5', size: '24' },
-		{ id: 'programCut', mix: '0', input: '6', label: 'PRGM 6', size: '24' },
-		{ id: 'programCut', mix: '0', input: '7', label: 'PRGM 7', size: '24' },
-		{ id: 'programCut', mix: '0', input: '8', label: 'PRGM 8', size: '24' },
-		{ id: 'transitionMix', mix: '0', type: 'Cut', label: 'Cut', size: '24' },
-		{ id: 'transitionMix', mix: '0', type: 'Fade', label: 'Fade', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '1', label: 'PRV 1', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '2', label: 'PRV 2', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '3', label: 'PRV 3', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '4', label: 'PRV 4', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '5', label: 'PRV 5', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '6', label: 'PRV 6', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '7', label: 'PRV 7', size: '24' },
+		{ id: 'PreviewInput', mix: 0, input: '8', label: 'PRV 8', size: '24' },
+		{ id: 'programCut', mix: 0, input: '1', label: 'PRGM 1', size: '24' },
+		{ id: 'programCut', mix: 0, input: '2', label: 'PRGM 2', size: '24' },
+		{ id: 'programCut', mix: 0, input: '3', label: 'PRGM 3', size: '24' },
+		{ id: 'programCut', mix: 0, input: '4', label: 'PRGM 4', size: '24' },
+		{ id: 'programCut', mix: 0, input: '5', label: 'PRGM 5', size: '24' },
+		{ id: 'programCut', mix: 0, input: '6', label: 'PRGM 6', size: '24' },
+		{ id: 'programCut', mix: 0, input: '7', label: 'PRGM 7', size: '24' },
+		{ id: 'programCut', mix: 0, input: '8', label: 'PRGM 8', size: '24' },
+		{ id: 'transitionMix', mix: 0, type: 'Cut', label: 'Cut', size: '24' },
+		{ id: 'transitionMix', mix: 0, type: 'Fade', label: 'Fade', size: '24' },
 		{ id: 'transition', label: 'AUTO', size: '24'}
 	];
 
@@ -68,18 +68,18 @@ exports.initPresets = function() {
 
 	// Mix 2-4
 	const mix2PreviewProgram = [
-		{ id: 'PreviewInput', mix: '1', input: '1', label: 'PRV MIX 2', size: '24' },
-		{ id: 'PreviewInput', mix: '2', input: '1', label: 'PRV MIX 3', size: '24' },
-		{ id: 'PreviewInput', mix: '3', input: '1', label: 'PRV MIX 4', size: '24' },
-		{ id: 'programCut', mix: '1', input: '1', label: 'PRGM MIX 2', size: '24' },
-		{ id: 'programCut', mix: '2', input: '1', label: 'PRGM MIX 3', size: '24' },
-		{ id: 'programCut', mix: '3', input: '1', label: 'PRGM MIX 4', size: '24' },
-		{ id: 'transitionMix', mix: '1', type: 'Cut', label: 'Cut MIX 2', size: '24' },
-		{ id: 'transitionMix', mix: '2', type: 'Cut', label: 'Cut MIX 3', size: '24' },
-		{ id: 'transitionMix', mix: '3', type: 'Cut', label: 'Cut MIX 4', size: '24' },
-		{ id: 'transitionMix', mix: '1', type: 'Fade', label: 'Fade MIX 2', size: '24' },
-		{ id: 'transitionMix', mix: '2', type: 'Fade', label: 'Fade MIX 3', size: '24' },
-		{ id: 'transitionMix', mix: '3', type: 'Fade', label: 'Fade MIX 4', size: '24' },
+		{ id: 'PreviewInput', mix: 1, input: '1', label: 'PRV MIX 2', size: '24' },
+		{ id: 'PreviewInput', mix: 2, input: '1', label: 'PRV MIX 3', size: '24' },
+		{ id: 'PreviewInput', mix: 3, input: '1', label: 'PRV MIX 4', size: '24' },
+		{ id: 'programCut', mix: 1, input: '1', label: 'PRGM MIX 2', size: '24' },
+		{ id: 'programCut', mix: 2, input: '1', label: 'PRGM MIX 3', size: '24' },
+		{ id: 'programCut', mix: 3, input: '1', label: 'PRGM MIX 4', size: '24' },
+		{ id: 'transitionMix', mix: 1, type: 'Cut', label: 'Cut MIX 2', size: '24' },
+		{ id: 'transitionMix', mix: 2, type: 'Cut', label: 'Cut MIX 3', size: '24' },
+		{ id: 'transitionMix', mix: 3, type: 'Cut', label: 'Cut MIX 4', size: '24' },
+		{ id: 'transitionMix', mix: 1, type: 'Fade', label: 'Fade MIX 2', size: '24' },
+		{ id: 'transitionMix', mix: 2, type: 'Fade', label: 'Fade MIX 3', size: '24' },
+		{ id: 'transitionMix', mix: 3, type: 'Fade', label: 'Fade MIX 4', size: '24' },
 	];
 
 	mix2PreviewProgram.forEach(item => {


### PR DESCRIPTION
**Issue**
There was an issue with the presets where the `mix` option was set as a string, where as when manually adding the action it correctly set it as a number, as the action logic is expecting.

**Impact**
Currently when a user uses the preset buttons for Send Input to Program the function will default to using `Cut` instead of `CutDirect`, which causes vMix to change preview to the chosen input and then use a cut transition. This means that the preview bus will always follow the program bus when using this presets, and also can flash up preview feedback on the wrong button momentarily.

**Fix**
I've updated the presets, and this has no impact on existing configurations but it is a change of behaviour going forwards and so people who may expect the use of `Cut` from the preset buttons may be caught off-guard when it uses `CutDirect` now instead. I've updated the patch notes to mention this change.

**Alternative Option**
The alternative to changing this default behaviour of this preset, would be to add a new action for `CutDirect`, and have an upgrade script transition all users with the correct option over to that action, and leave current users with the 'bad' preset as is and change the current action to only use `Cut`. I don't recommend this as it's more involved, adds more actions, and the current fix in this PR doesn't change existing functionality, only future functionality when a user creates buttons from the presets.