### PR TITLE
Feat: Activator support, 8 Replay Cameras, Call Audio Feedback, minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ and if there is more than one parameter use "&" as a separator between them like
 * Fixed a bug with audio toggle on Master Bus, and added Toggle/On/Off action.
 * Added GUID Support in feedbacks, GUID can now be used in the input field in both actions and feedbacks.
 * Fixed a bug where XML data containing a carriage return would break parsing
+
+**v1.2.10**
+* Added support for vMix Activators, allowing some feedbacks to be more responsive
+* Added support for up to 8 replay cameras
+* Added vMix Call audio source feedback
+* Fixed a bug with the SelectPlayList actions missing param name

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,4 +1,4 @@
-exports.getActions = function() {
+exports.getActions = function () {
 	const mixSelect = {
 		type: 'dropdown',
 		label: 'Mix',
@@ -103,7 +103,7 @@ exports.getActions = function() {
 		},
 
 		SetTransitionEffect: {
-			label: 'Transition - Set Auto Transition Effect',			
+			label: 'Transition - Set Auto Transition Effect',
 			options: [
 				{
 					type: 'dropdown',
@@ -146,7 +146,7 @@ exports.getActions = function() {
 		},
 
 		SetTransitionDuration: {
-			label: 'Transition - Set Auto Transition Duration',			
+			label: 'Transition - Set Auto Transition Duration',
 			options: [
 				{
 					type: 'dropdown',
@@ -326,7 +326,7 @@ exports.getActions = function() {
 					type: 'textinput',
 					label: 'MultiView Input',
 					id: 'input'
-				}, 
+				},
 				{
 					type: 'textinput',
 					label: 'Layer',
@@ -343,7 +343,7 @@ exports.getActions = function() {
 					type: 'textinput',
 					label: 'MultiView Input',
 					id: 'input'
-				},			
+				},
 				{
 					type: 'textinput',
 					label: 'Layer',
@@ -355,14 +355,14 @@ exports.getActions = function() {
 					label: 'Input to use on Layer',
 					id: 'LayerInput',
 					default: 1
-				},			 
+				},
 			]
 		},
 
 		VirtualSet: {
 			label: 'VirtualSet - Zoom To Selected Preset',
 			options: [
-				input, 
+				input,
 				{
 					type: 'textinput',
 					label: 'Preset (1-4)',
@@ -375,7 +375,7 @@ exports.getActions = function() {
 		VideoCallAudioSource: {
 			label: 'VideoCall - Select Audio Source',
 			options: [
-				input, 
+				input,
 				{
 					type: 'dropdown',
 					label: 'Bus',
@@ -399,7 +399,7 @@ exports.getActions = function() {
 		VideoCallVideoSource: {
 			label: 'VideoCall - Select Video Source',
 			options: [
-				input, 
+				input,
 				{
 					type: 'dropdown',
 					label: 'Select Output',
@@ -461,7 +461,7 @@ exports.getActions = function() {
 						{ id: 'BusXAudioOff', label: 'Set Bus Audio OFF' },
 					]
 				},
-]
+			]
 		},
 
 		Audio: {
@@ -807,27 +807,53 @@ exports.getActions = function() {
 		},
 
 		replayACamera: {
-			label: 'Replay - Replay A Camera',
+			label: 'Replay - A Camera',
 			options: [
 				{
 					type: 'dropdown',
 					label: 'Camera',
 					id: 'functionID',
 					default: 'ReplayACamera1',
-					choices: ['ReplayACamera1', 'ReplayACamera2', 'ReplayACamera3', 'ReplayACamera4'].map((item, index) => ({ id: item, label: `Camera ${index + 1}` }))
+					choices: [1, 2, 3, 4, 5, 6, 7, 8].map((item) => ({ id: `ReplayACamera${item}`, label: `Camera ${item}` }))
 				}
 			]
 		},
 
 		replayBCamera: {
-			label: 'Replay - Replay B Camera',
+			label: 'Replay - B Camera',
 			options: [
 				{
 					type: 'dropdown',
 					label: 'Camera',
 					id: 'functionID',
 					default: 'ReplayBCamera1',
-					choices: ['ReplayBCamera1', 'ReplayBCamera2', 'ReplayBCamera3', 'ReplayBCamera4'].map((item, index) => ({ id: item, label: `Camera ${index + 1}` }))
+					choices: [1, 2, 3, 4, 5, 6, 7, 8].map((item) => ({ id: `ReplayBCamera${item}`, label: `Camera ${item}` }))
+				}
+			]
+		},
+
+		replayCamera: {
+			label: 'Replay - Selected Channel Camera',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Camera',
+					id: 'functionID',
+					default: 'ReplayCamera1',
+					choices: [1, 2, 3, 4, 5, 6, 7, 8].map((item) => ({ id: `ReplayCamera${item}`, label: `Camera ${item}` }))
+				}
+			]
+		},
+
+		replaySelectChannel: {
+			label: 'Replay - Select Channel',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Channel',
+					id: 'functionID',
+					default: 'ReplaySelectChannelAB',
+					choices: ['ReplaySelectChannelAB', 'ReplaySelectChannelA', 'ReplaySelectChannelB'].map((item) => ({ id: item, label: item.substr(19) }))
 				}
 			]
 		},
@@ -1121,7 +1147,7 @@ exports.getActions = function() {
 	};
 };
 
-exports.executeAction = function(action) {
+exports.executeAction = function (action) {
 	var opt = action.options || {};
 	var cmd;
 
@@ -1132,26 +1158,26 @@ exports.executeAction = function(action) {
 			cmd = `FUNCTION Cut Input=${opt.input}&Mix=${opt.mix}`;
 		}
 	}
-	
+
 	else if (action.action === 'outputSet') {
 		cmd = `FUNCTION ${opt.functionID} Value=${opt.value}`;
 		if (opt.value === 'Input') {
 			cmd += `&Input=${opt.input}`;
 		}
 	}
-	
+
 	else if (action.action === 'SelectPlayList') {
-		cmd = `FUNCTION SelectPlayList ${opt.playlistName}`;
+		cmd = `FUNCTION SelectPlayList value=${opt.playlistName}`;
 	}
-	
+
 	else if (action.action === 'SetVolumeFade') {
 		cmd = `FUNCTION SetVolumeFade Value=${opt.fadeMin},${opt.fadeTime !== undefined ? opt.fadeTime : '2000'}&input=${opt.input}`;
 	}
-	
+
 	else if (action.action === 'command') {
 		cmd = `FUNCTION ${opt.command}`;
 	}
-	
+
 	else if (action.action === 'MultiViewOverlay') {
 		cmd = `FUNCTION ${opt.functionID} Input=${opt.input}&Value=${opt.selectedIndex}`;
 	}
@@ -1176,7 +1202,7 @@ exports.executeAction = function(action) {
 
 		cmd = `FUNCTION SetText Input=${opt.input}&SelectedIndex=${opt.selectedIndex}&Value=${text}`;
 	}
-	
+
 	else if (action.action === 'SelectTitlePreset') {
 		cmd = `FUNCTION SelectTitlePreset Input=${opt.input}&Value=${opt.selectedIndex}`;
 	}
@@ -1191,7 +1217,7 @@ exports.executeAction = function(action) {
 
 	else if (action.action === 'videoActions' || action.action === 'videoMark') {
 		if (opt.inputType == true) {
-			cmd = `FUNCTION ${opt.functionID} Input=0`;	
+			cmd = `FUNCTION ${opt.functionID} Input=0`;
 		} else {
 			cmd = `FUNCTION ${opt.functionID} Input=${opt.input}`;
 		}
@@ -1216,9 +1242,9 @@ exports.executeAction = function(action) {
 
 	else if (action.action === 'BusXAudio') {
 		if (opt.value == 'Master') {
-			if (opt.functionID == 'BusXAudio') {cmd = `FUNCTION MasterAudio`};
-			if (opt.functionID == 'BusXAudioOn') {cmd = `FUNCTION MasterAudioON`;}
-			if (opt.functionID == 'BusXAudioOff') {cmd = `FUNCTION MasterAudioOFF`;}
+			if (opt.functionID == 'BusXAudio') { cmd = `FUNCTION MasterAudio` };
+			if (opt.functionID == 'BusXAudioOn') { cmd = `FUNCTION MasterAudioON`; }
+			if (opt.functionID == 'BusXAudioOff') { cmd = `FUNCTION MasterAudioOFF`; }
 		} else {
 			cmd = `FUNCTION ${opt.functionID} Value=${opt.value}`;
 		}
@@ -1243,11 +1269,11 @@ exports.executeAction = function(action) {
 			cmd = `FUNCTION ${opt.functionID}`;
 		}
 	}
-	
+
 	else if (action.action === 'replayToggleCamera') {
 		cmd = `FUNCTION ReplayToggleSelectedEventCamera${opt.camera}`;
 	}
-	
+
 	else {
 		const vMixFunction = opt.functionID || action.action;
 		const params = ['duration', 'input', 'mix', 'selectedIndex', 'value']

--- a/src/activators.js
+++ b/src/activators.js
@@ -1,0 +1,309 @@
+const events = {
+	inputProgram: [
+		'Input',
+		'InputMix2',
+		'InputMix3',
+		'InputMix4'
+	],
+	inputPreview: [
+		'InputPreview',
+		'InputPreviewMix2',
+		'InputPreviewMix3',
+		'InputPreviewMix4'
+	],
+	inputDynamic: [
+		'InputDynamic1',
+		'InputDynamic2',
+		'InputDynamic3',
+		'InputDynamic4'
+	],
+	inputState: [
+		'InputPlaying',
+		'InputVolume',
+		'InputAudio',
+		'InputSolo'
+	],
+	inputAudio: [
+		'InputHeadphones',
+		'InputMasterAudio',
+		'InputBusAAudio',
+		'InputBusBAudio',
+		'InputBusCAudio',
+		'InputBusDAudio',
+		'InputBusEAudio',
+		'InputBusFAudio',
+		'InputBusGAudio'
+	],
+	overlays: [
+		'Overlay1',
+		'Overlay2',
+		'Overlay3',
+		'Overlay4'
+	],
+	vMixState: [
+		'FadeToBlack',
+		'Recording',
+		'Streaming',
+		'External',
+		'MultiCorder',
+		'Fullscreen'
+	],
+	busAudio: [
+		'MasterVolume',
+		'MasterAudio',
+		'MasterHeadphones',
+		'BusAVolume',
+		'BusAAudio',
+		'BusBVolume',
+		'BusBAudio',
+		'BusCVolume',
+		'BusCAudio',
+		'BusDVolume',
+		'BusDAudio',
+		'BusEVolume',
+		'BusEAudio',
+		'BusFVolume',
+		'BusFAudio',
+		'BusGVolume',
+		'BusGAudio'
+	],
+	replay: [
+		'ReplayPlaying',
+		'ReplayCamera1',
+		'ReplayCamera2',
+		'ReplayCamera3',
+		'ReplayCamera4',
+		'ReplayCamera5',
+		'ReplayCamera6',
+		'ReplayCamera7',
+		'ReplayCamera8',
+		'ReplayACamera1',
+		'ReplayACamera2',
+		'ReplayACamera3',
+		'ReplayACamera4',
+		'ReplayACamera5',
+		'ReplayACamera6',
+		'ReplayACamera7',
+		'ReplayACamera8',
+		'ReplayBCamera1',
+		'ReplayBCamera2',
+		'ReplayBCamera3',
+		'ReplayBCamera4',
+		'ReplayBCamera5',
+		'ReplayBCamera6',
+		'ReplayBCamera7',
+		'ReplayBCamera8',
+		'ReplayRecording',
+		'ReplayPlayForward',
+		'ReplayPlayBackward'
+	]
+};
+
+const bufferDelay = 50;
+const feedbackBuffer = new Set();
+const variableBuffer = new Set();
+let bufferCheckTimeout;
+
+exports.parseActivactor = function (message) {
+	const updateBuffer = (type, name, value) => {
+		if (type === 'feedback') {
+			feedbackBuffer.add(name);
+		} else {
+
+			// Adds variable to be updated, or updates the pending value if it already exists in set
+			let hit = false;
+			variableBuffer.forEach(item => {
+				if (item.name === name) {
+					hit = true;
+					item.value = value;
+				}
+			});
+
+			if (!hit) {
+				variableBuffer.add({ name, value });
+			}
+		}
+
+		if (!bufferCheckTimeout) {
+			bufferCheckTimeout = setTimeout(() => {
+				feedbackBuffer.forEach(feedback => {
+					this.checkFeedbacks(feedback);
+				});
+				variableBuffer.forEach(variable => {
+					this.setVariable(variable.name, variable.value);
+				});
+
+				feedbackBuffer.clear();
+				variableBuffer.clear();
+				bufferCheckTimeout = null;
+			}, bufferDelay);
+		} else {
+		}
+	};
+
+	const params = message.split(' ');
+
+	if (events.inputProgram.includes(params[0]) || events.inputPreview.includes(params[0])) {
+		// Note - InputMix2 to InputMix4 activator messages are inconsistent, and may not always reflect what's live in vMix
+		const mix = events.inputProgram.includes(params[0]) ? events.inputProgram.indexOf(params[0]) : events.inputPreview.indexOf(params[0]);
+		const input = params[1];
+		const state = params[2];
+		const type = events.inputProgram.includes(params[0]) ? 'program' : 'preview';
+
+		if (state === '1') {
+			this.data.mix[mix][type] = parseInt(input, 10);
+			updateBuffer('feedback', type === 'program' ? 'inputLive' : 'inputPreview');
+		}
+	}
+
+	else if (events.inputDynamic.includes(params[0])) {
+		// Waiting on v24
+	}
+
+	else if (events.inputState.includes(params[0])) {
+		const input = this.data.inputs.find(input => input.number === params[1]);
+		if (!input) {
+			return
+		}
+
+		if (params[0] === 'InputPlaying') {
+			input.state = params[2] === '0' ? 'Paused' : 'Running';
+		}
+
+		else if (params[0] === 'InputVolume') {
+			const volume = Math.round(parseFloat(params[2] * 100));
+
+			let inputName = input.shortTitle.replace(/[^a-z0-9-_.]+/gi, '');
+			updateBuffer('variable', `input_volume_${inputName}`, volume);
+			updateBuffer('feedback', 'inputVolumeLevel');
+		}
+
+		else if (params[0] === 'InputAudio') {
+			input.muted = params[2] === '1' ? 'False' : 'True';
+			updateBuffer('feedback', 'inputMute');
+		}
+
+		else if (params[0] === 'InputSolo') {
+			input.solo = params[2] === '0' ? 'False' : 'True';
+			updateBuffer('feedback', 'inputSolo');
+		}
+
+	}
+
+	else if (events.inputAudio.includes(params[0])) {
+		const input = this.data.inputs.find(input => input.number === params[1]);
+		if (!input) {
+			return
+		}
+
+		if (params[0] === 'InputHeadphones') {
+			// Unused
+		} else {
+			let bus = params[0] === 'InputMasterAudio' ? 'M' : params[0][8];
+			let audiobusses = input.audiobusses.split(',');
+
+			if (params[2] === '1') {
+				audiobusses.push(bus);
+			} else {
+				audiobusses = audiobusses.filter(item => item !== bus);
+			}
+
+			input.audiobusses = audiobusses.join(',');
+			updateBuffer('feedback', 'inputBusRouting');
+		}
+	}
+
+	else if (params[0].startsWith('InputVolumeChannelMixer')) {
+		const input = this.data.inputs.find(input => input.number === params[1]);
+		if (!input) {
+			return
+		}
+
+		const channel = params[0].substr(23);
+		this.activatorData.channelMixer[input.key][channel - 1].volume = Math.round(parseFloat(params[2] * 100));
+	}
+
+	else if (events.overlays.includes(params[0])) {
+		// Unused - Activator doesn't differentiate between preview and program overlays
+	}
+
+	else if (events.vMixState.includes(params[0])) {
+		const status = params[0][0].toLowerCase() + params[0].substr(1);
+
+		this.data.status[status] = params[2] === '1';
+		updateBuffer('feedback', 'status');
+	}
+
+	else if (events.busAudio.includes(params[0])) {
+		let id = params[0].startsWith('Master') ? 'master' : params[0][3];
+		if (!params[0].startsWith('Master')) {
+			id = 'bus' + id;
+		}
+
+		if (params[0] === 'MasterHeadphones') {
+			updateBuffer('variable', 'bus_volume_headphones', Math.round(parseFloat(params[1] * 100)));
+		}
+		else if (params[0].endsWith('Volume')) {
+			const bus = this.data.audio.find(item => item.bus === id);
+			if (bus) {
+				bus.volume = Math.round(parseFloat(params[2] * 100)).toString();
+			}
+
+			const variableID = params[0].startsWith('Master') ? 'master' : params[0][3];
+			updateBuffer('variable', `bus_volume_${variableID.toLowerCase()}`, Math.round(parseFloat(params[1] * 100)));
+			updateBuffer('feedback', 'busVolumeLevel');
+			updateBuffer('feedback', 'liveBusVolume');
+
+		}
+		else if (params[0].endsWith('Audio')) {
+			const bus = this.data.audio.find(item => item.bus === id);
+			if (bus) {
+				bus.muted = params[1] === '0' ? 'True' : 'False';
+			}
+
+			updateBuffer('feedback', 'busMute');
+		}
+	}
+
+	else if (events.replay.includes(params[0])) {
+		if (params[0].startsWith('ReplayCamera')) {
+			// Unused
+		}
+		else if (params[0].includes('Camera')) {
+			const camera = params[0][6];
+
+			if (params[1] === '1') {
+				this.data.replay['camera' + camera] = params[0].substr(13);
+				updateBuffer('feedback', 'replayCamera');
+			}
+		}
+		else if (params[0] === 'ReplayPlayForward') {
+			// Unused
+		}
+		else if (params[0] === 'ReplayPlayBackward') {
+			// Unused
+		}
+	}
+
+	else if (params[0].startsWith('VideoCallAudioSource')) {
+		const input = this.data.inputs.find(input => input.number === params[1]);
+		if (!input) {
+			return
+		}
+
+		if (!this.activatorData.videoCall[input.key]) {
+			this.activatorData.videoCall[input.key] = {};
+		}
+
+		this.activatorData.videoCall[input.key].audioSource = params[0].substr(20);
+		updateBuffer('feedback', 'videoCallAudioSource');
+	}
+
+	else if (params[0] === 'ButtonPress') {
+		// Unused
+	}
+
+	else {
+		this.debug(`Unknown vMix activator: ${params[0]}`)
+	}
+};

--- a/src/api.js
+++ b/src/api.js
@@ -82,6 +82,8 @@ exports.parseAPI = function (body) {
 
 						return overlay;
 					});
+				} else {
+					data.overlay = [];
 				}
 
 				if (input.replay) {
@@ -116,18 +118,19 @@ exports.parseAPI = function (body) {
 					audio[key][0].$.bus = key;
 					data.push(audio[key][0].$);
 				});
+				
+				if (!this.data.connected) {
+					data.forEach(output => {
+						const busID = output.bus === 'master' ? 'master' : output.bus.substr(3).toLowerCase();
+						const volume = Math.round(parseFloat(output.volume));
+						this.setVariable(`bus_volume_${busID}`, volume);
 
-				data.forEach(output => {
-					const busID = output.bus === 'master' ? 'master' : output.bus.substr(3);
-					const volume = Math.round(parseFloat(output.volume));
-
-					this.setVariable(`bus_volume_${busID}`, volume);
-
-					if (output.bus === 'master') {
-						const headphonesVolume = Math.round(parseFloat(output.headphonesVolume));
-						this.setVariable('bus_volume_headphones', headphonesVolume);
-					}
-				});
+						if (output.bus === 'master') {
+							const headphonesVolume = Math.round(parseFloat(output.headphonesVolume));
+							this.setVariable('bus_volume_headphones', headphonesVolume);
+						}
+					});
+				}
 
 				return data;
 			};
@@ -187,7 +190,33 @@ exports.parseAPI = function (body) {
 				data.replay.events = replayInput.replay.events;
 				data.replay.cameraA = replayInput.replay.cameraA;
 				data.replay.cameraB = replayInput.replay.cameraB;
+				data.replay.channelMode = replayInput.replay.channelMode; 
+
+				if (data.replay.channelMode === 'AB' && this.data.replay.cameraB) {
+					data.replay.cameraB = this.data.replay.cameraB;
+				}
 			}
+
+			// Update channel mixer
+			data.inputs.forEach(input => {
+				if (!this.activatorData.channelMixer[input.key]) {
+					this.activatorData.channelMixer[input.key] = [];
+					for (let i = 0; i < 16; i++) {
+						this.activatorData.channelMixer[input.key].push({ channel: i + 1, volume: 1 });
+					}
+				}
+
+				if (input.type === 'VideoCall' && !this.activatorData.videoCall[input.key]) {
+					this.activatorData.videoCall[input.key] = { audioSource: '' };
+				}
+			});
+
+			// Clean up removed inputs from channel mixer
+			Object.keys(this.activatorData.channelMixer).forEach(key => {
+				if (!data.inputs.map(input => input.key).includes(key)) {
+					delete this.activatorData.channelMixer[key];
+				}
+			});
 
 			// Check for changes to update feedbacks
 			const changes = new Set([]);
@@ -205,7 +234,7 @@ exports.parseAPI = function (body) {
 			}
 
 			// Check for input changes
-			if (!_.isEqual(data.inputs, this.data.inputs) || inputCheck) {
+			if (!this.data.connected && (!_.isEqual(data.inputs, this.data.inputs) || inputCheck)) {
 				changes.add('videoTimer');
 				changes.add('inputMute');
 				changes.add('inputAudio');
@@ -213,16 +242,21 @@ exports.parseAPI = function (body) {
 				changes.add('inputBusRouting');
 				changes.add('titleLayer');
 				changes.add('inputVolumeLevel');
+			}
+
+			if (!_.isEqual(data.inputs, this.data.inputs) || inputCheck) {
+				changes.add('videoTimer');
+				changes.add('titleLayer');
 				changes.add('liveInputVolume');
 			}
 
 			// Check for status changes
-			if (!_.isEqual(data.status, this.data.status) || (data.connected !== this.data.connected) || inputCheck) {
+			if (!_.isEqual(data.status, this.data.status)) {
 				changes.add('status');
 			}
 
 			// Check Audio status
-			if (!_.isEqual(data.audio, this.data.audio) || inputCheck) {
+			if (!this.data.connected && (!_.isEqual(data.audio, this.data.audio) || inputCheck)) {
 				changes.add('busMute');
 				changes.add('busVolumeLevel');
 				changes.add('liveBusVolume');
@@ -243,7 +277,7 @@ exports.parseAPI = function (body) {
 				}
 
 				// Check input has volume and a different or no previous volume
-				if (input.volume !== undefined && (previousState === undefined || input.volume !== previousState.volume)) {
+				if (!this.data.connected && input.volume !== undefined && (previousState === undefined || input.volume !== previousState.volume)) {
 					const volume = Math.round(parseFloat(input.volume));
 
 					// Remove symbols other than - _ . from the input title
@@ -257,6 +291,7 @@ exports.parseAPI = function (body) {
 				changes.add('replayStatus');
 				changes.add('replayEvents');
 				changes.add('replayCamera');
+				changes.add('replaySelectedChannel');
 			}
 
 			data.startup = false;

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -1,4 +1,4 @@
-exports.initFeedbacks = function() {
+exports.initFeedbacks = function () {
 	const feedbacks = {};
 
 	const foregroundColor = {
@@ -138,15 +138,15 @@ exports.initFeedbacks = function() {
 			backgroundColorProgram,
 			{
 				type: 'dropdown',
-					label: 'Stream Feedback Value',
-					id: 'value',
-					default: '',
-					choices: [
-						{ id: '', label: 'All' },
-						{ id: '0', label: '0' },
-						{ id: '1', label: '1' },
-						{ id: '2', label: '2' }
-					]
+				label: 'Stream Feedback Value',
+				id: 'value',
+				default: '',
+				choices: [
+					{ id: '', label: 'All' },
+					{ id: '0', label: '0' },
+					{ id: '1', label: '1' },
+					{ id: '2', label: '2' }
+				]
 			}
 		]
 	};
@@ -178,6 +178,7 @@ exports.initFeedbacks = function() {
 		description: 'Indicate if an inputs Audio is ON',
 		options: [input, foregroundColor, backgroundColorProgram]
 	};
+
 	feedbacks.inputSolo = {
 		label: 'Audio - Input solo',
 		description: 'Indicate if an input is set to Solo',
@@ -204,7 +205,7 @@ exports.initFeedbacks = function() {
 				default: this.rgb(255, 255, 0)
 			}
 		]
-  };
+	};
 
 	feedbacks.liveInputVolume = {
 		label: 'Audio - Input live dB value',
@@ -249,7 +250,7 @@ exports.initFeedbacks = function() {
 			}
 		]
 	};
-	
+
 	feedbacks.liveBusVolume = {
 		label: 'Audio - Bus live dB value',
 		description: 'Indicate what the live dB value on a bus is',
@@ -317,7 +318,7 @@ exports.initFeedbacks = function() {
 			backgroundColorPreview
 		]
 	};
-  
+
 	feedbacks.busVolumeLevel = {
 		label: 'Audio - Bus Volume',
 		description: 'Indicate if an output bus fader is within a set range',
@@ -392,7 +393,7 @@ exports.initFeedbacks = function() {
 	};
 
 	feedbacks.replayCamera = {
-		label: 'Replay - Recording/Live',
+		label: 'Replay - Camera Live',
 		description: 'Indicates current recording or live status of a replay input',
 		options: [
 			{
@@ -402,7 +403,8 @@ exports.initFeedbacks = function() {
 				default: 'A',
 				choices: [
 					{ id: 'A', label: 'Replay A' },
-					{ id: 'B', label: 'Replay B' }
+					{ id: 'B', label: 'Replay B' },
+					{ id: 'selected', label: 'Replay Selected' }
 				]
 			},
 			{
@@ -410,17 +412,54 @@ exports.initFeedbacks = function() {
 				label: 'Camera',
 				id: 'camera',
 				default: '1',
-				choices: ['1', '2', '3', '4'].map(id => ({ id, label: id }))
+				choices: ['1', '2', '3', '4', '5', '6', '7', '8'].map(id => ({ id, label: id }))
 			},
 			foregroundColor,
 			backgroundColorProgram
 		]
 	};
 
+	feedbacks.replaySelectedChannel = {
+		label: 'Replay - Selected Channel',
+		description: 'Indicates currently selected channel',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Replay Channel',
+				id: 'channel',
+				default: 'AB',
+				choices: [
+					{ id: 'AB', label: 'A|B' },
+					{ id: 'A', label: 'A' },
+					{ id: 'B', label: 'B' }
+				]
+			},
+			foregroundColor,
+			backgroundColorProgram
+		]
+	};
+
+	feedbacks.videoCallAudioSource = {
+		label: 'Video Call - Audio Source',
+		description: 'Indicates audio source for a video call',
+		options: [
+			input,
+			{
+				type: 'dropdown',
+				label: 'Source',
+				id: 'source',
+				default: 'Master',
+				choices: ['Master', 'Headphones', 'A', 'B', 'C', 'D', 'E', 'F', 'G'].map((id, index) => ({ id: index > 1 ? `Bus${id}` : id, label: id }))
+			},
+			foregroundColor,
+			backgroundColorProgram
+		]
+	}
+
 	return feedbacks;
 };
 
-exports.executeFeedback = function(feedback, bank) {
+exports.executeFeedback = function (feedback, bank) {
 	const int = RegExp(/^\d+$/);
 
 	const getInput = value => {
@@ -430,7 +469,7 @@ exports.executeFeedback = function(feedback, bank) {
 			input = this.data.inputs.find(item => item.number === value);
 		} else {
 			input = this.data.inputs.find(item => item.shortTitle === value || item.title === value || item.key === value);
-		}	
+		}
 
 		return input;
 	};
@@ -444,7 +483,7 @@ exports.executeFeedback = function(feedback, bank) {
 		}
 
 		const previewTitle = this.data.inputs[this.data.mix[mix][type] - 1].shortTitle;
-		const guidKey = this.data.inputs[this.data.mix[mix][type] -1].key;	
+		const guidKey = this.data.inputs[this.data.mix[mix][type] - 1].key;
 		const idCheck = int.test(feedback.options.input) && feedback.options.input == this.data.mix[mix][type];
 		const titleCheck = !int.test(feedback.options.input) && feedback.options.input === previewTitle;
 		const guidCheck = feedback.options.input == guidKey;
@@ -452,7 +491,7 @@ exports.executeFeedback = function(feedback, bank) {
 			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
 		}
 	}
-	
+
 	else if (feedback.type === 'overlayStatus') {
 		let input = getInput(feedback.options.input);
 		let preview = false;
@@ -482,7 +521,7 @@ exports.executeFeedback = function(feedback, bank) {
 			};
 		}
 	}
-	
+
 	else if (feedback.type === 'videoTimer') {
 		let input = getInput(feedback.options.input);
 
@@ -524,10 +563,10 @@ exports.executeFeedback = function(feedback, bank) {
 		if (bank.text != '') {
 			return { color: color(), text: bank.text + `\\n ${min}:${sec}.${ms}` };
 		} else {
-			return { color: color(), text: bank.text + `${min}:${sec}.${ms}` };	
+			return { color: color(), text: bank.text + `${min}:${sec}.${ms}` };
 		}
 	}
-	
+
 	else if (feedback.type === 'status') {
 		if (feedback.options.status === 'connection') {
 			if (this.data.connected) return { color: feedback.options.fg, bgcolor: feedback.options.bg };
@@ -539,7 +578,7 @@ exports.executeFeedback = function(feedback, bank) {
 			}
 		}
 	}
-	
+
 	else if (feedback.type === 'busMute') {
 		const busID = feedback.options.bus === 'Master' ? 'master' : `bus${feedback.options.bus}`;
 		const bus = this.data.audio.find(item => item.bus === busID);
@@ -548,7 +587,7 @@ exports.executeFeedback = function(feedback, bank) {
 			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
 		}
 	}
-	
+
 	else if (feedback.type === 'inputMute') {
 		let input = getInput(feedback.options.input);
 
@@ -572,7 +611,7 @@ exports.executeFeedback = function(feedback, bank) {
 			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
 		}
 	}
-	
+
 	else if (feedback.type === 'inputBusRouting') {
 		let input = getInput(feedback.options.input);
 		const busID = feedback.options.bus === 'Master' ? 'M' : feedback.options.bus;
@@ -581,7 +620,7 @@ exports.executeFeedback = function(feedback, bank) {
 			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
 		}
 	}
-	
+
 	else if (feedback.type === 'liveInputVolume') {
 		let input = getInput(feedback.options.input);
 
@@ -589,16 +628,16 @@ exports.executeFeedback = function(feedback, bank) {
 		if (!input) {
 			return
 		}
-		
+
 		var dBLeft = parseFloat(input.meterF1);
 		var dBRight = parseFloat(input.meterF2);
 
 		dBLeft = (20 * Math.log(dBLeft) / Math.LN10);
 		dBRight = (20 * Math.log(dBRight) / Math.LN10);
-		
+
 		dB = Math.max(dBLeft, dBRight);
 		dB = +dB.toFixed(1);
-		
+
 		const color = () => {
 			if (dB > -1) {
 				return feedback.options.color;
@@ -635,20 +674,20 @@ exports.executeFeedback = function(feedback, bank) {
 		}
 
 		else {
-			const busID = feedback.options.bus === 'Master' ? 'master' : ( 'bus' + feedback.options.bus);
+			const busID = feedback.options.bus === 'Master' ? 'master' : ('bus' + feedback.options.bus);
 			const bus = this.data.audio.find(output => output.bus === busID);
 			if (bus !== undefined) {
 				dBLeft = parseFloat(bus.meterF1);
 				dBRight = parseFloat(bus.meterF2);
-				}
-		}	
+			}
+		}
 
 		dBLeft = (20 * Math.log(dBLeft) / Math.LN10);
 		dBRight = (20 * Math.log(dBRight) / Math.LN10);
-		
+
 		dB = Math.max(dBLeft, dBRight);
 		dB = +dB.toFixed(1);
-		
+
 		const color = () => {
 			if (dB > -1) {
 				return feedback.options.color;
@@ -706,14 +745,14 @@ exports.executeFeedback = function(feedback, bank) {
 			const bus = this.data.audio.find(output => output.bus === 'master');
 			volume = parseFloat(bus.headphonesVolume);
 		}
-		
+
 		else {
-			const busID = feedback.options.bus === 'Master' ? 'master' : ( 'bus' + feedback.options.bus);
+			const busID = feedback.options.bus === 'Master' ? 'master' : ('bus' + feedback.options.bus);
 			const bus = this.data.audio.find(output => output.bus === busID);
 			if (bus !== undefined) {
 				volume = parseFloat(bus.volume);
 			}
-		}	
+		}
 
 		const volumeInRange = {
 			'eq': volume === value,
@@ -744,21 +783,42 @@ exports.executeFeedback = function(feedback, bank) {
 			return { text: bank.text + text.value };
 		}
 	}
-	
+
 	else if (feedback.type === 'replayStatus') {
 		if (this.data.replay[feedback.options.status]) {
 			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
 		}
 	}
-	
+
 	else if (feedback.type === 'replayEvents') {
 		if (this.data.replay.events === feedback.options.events) {
 			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
 		}
 	}
-	
+
 	else if (feedback.type === 'replayCamera') {
-		if (this.data.replay['camera' + feedback.options.channel] === feedback.options.camera) {
+		let channel = feedback.options.channel;
+		if (channel === 'selected') {
+			// Backways compatibility - Default to channel A if prior to v24
+			channel = this.data.replay.channelMode ? this.data.replay.channelMode : 'A';
+			if (channel === 'AB') channel = 'A';
+		}
+
+		if (this.data.replay['camera' + channel] === feedback.options.camera) {
+			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
+		}
+	}
+
+	else if (feedback.type === 'replaySelectedChannel') {
+		if (this.data.replay.channelMode && this.data.replay.channelMode === feedback.options.channel) {
+			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
+		}
+	}
+
+	else if (feedback.type === 'videoCallAudioSource') {
+		let input = getInput(feedback.options.input);
+
+		if (input && this.activatorData.videoCall[input.key] && this.activatorData.videoCall[input.key].audioSource === feedback.options.source) {
 			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
 		}
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,16 @@ class VMixInstance extends instance_skel {
 				cameraB: '0'
 			}
 		};
+		this.activatorData = {
+			channelMixer: {},
+			replay: {
+				playForward: {
+					A: true,
+					B: true
+				}
+			},
+			videoCall: {}
+		};
 
 		this.config.host = this.config.host || '127.0.0.1';
 		this.config.tcpPort = this.config.tcpPort || 8099;

--- a/src/tcp.js
+++ b/src/tcp.js
@@ -1,5 +1,6 @@
 const tcp = require('../../../tcp');
 const { parseAPI } = require('./api');
+const { parseActivactor } = require('./activators');
 
 exports.init = function () {
 	if (this.socket !== undefined) {
@@ -29,12 +30,12 @@ exports.init = function () {
 
 			if (this.config.apiPollInterval != 0) {
 				this.socket.send('XML\r\n');
+				this.socket.send('SUBSCRIBE ACTS\r\n');
 				this.pollAPI = setInterval(() => {
 					this.socket.send('XML\r\n');
 				}, this.config.apiPollInterval < 100 ? 100 : this.config.apiPollInterval);
 			}
 		});
-
 
 		const processMessages = (message) => {
 
@@ -44,6 +45,11 @@ exports.init = function () {
 				const stop = message.indexOf('</vmix>') + 7;
 
 				parseAPI.bind(this)(message.slice(start, stop));
+			}
+					
+			// Activators
+			else if (message.includes('ACTS OK')) {
+				parseActivactor.bind(this)(message.substr(8));
 			}
 		};
 		


### PR DESCRIPTION
Version bump to v1.2.10

Added activator support by subscribing to activator messages on the TCP connection.

Several messages are currently unused as there's either no feedback that requires them, or require further updates in vMix v24 before they are of use.

Activators that do change feedback, or variables, (such as prv/prgm feedback, or volume variables) are buffered and set to update no faster than once every 50ms. This is fine in testing, and improves the responsiveness of feedback greatly and in some situations can allow for slower API polling without impact on feedback responsiveness. Activator support has also reduced the number of unnecessary checkFeedbacks and setVariable calls.

Resolves #53 
Fixes #58 
Fixes #62 