### PR TITLE
Fixing: calling inputAudio feedback on activator message (issue #73)

### DIFF
--- a/src/activators.js
+++ b/src/activators.js
@@ -198,6 +198,7 @@ exports.parseActivactor = function (message) {
 		else if (params[0] === 'InputAudio') {
 			input.muted = params[2] === '1' ? 'False' : 'True';
 			updateBuffer('feedback', 'inputMute');
+			updateBuffer('feedback', 'inputAudio');
 		}
 
 		else if (params[0] === 'InputSolo') {


### PR DESCRIPTION
Fixing issue #73, which describes how the `inputAudio` feedback is not called when and `InputAudio`  activator message is received.