### PR TITLE
Adding: Toggle/On/Off options to Audio - Route Input to Bus action

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -438,7 +438,22 @@ exports.getActions = function () {
 
 		AudioBus: {
 			label: 'Audio - Route Input to Bus',
-			options: [input, audioBusMaster]
+			options: [
+				input,
+				audioBusMaster, 
+				{
+					type: 'dropdown',
+					label: 'Option',
+					id: 'functionID',
+					default: 'AudioBus',
+					choices: [
+						{ id: 'AudioBus', label: 'Toggle' },
+						{ id: 'AudioBusOn', label: 'On' },
+						{ id: 'AudioBusOff', label: 'Off' },
+					]
+				},
+				
+			]
 		},
 
 		BusXSendToMaster: {


### PR DESCRIPTION
Implements issue bitfocus/companion#1351

- Adds `Toggle`, `On`, and `Off` options to `Audio - Route Input to Bus` action
- Sets `Toggle` as default for backwards compatibility

![image](https://user-images.githubusercontent.com/5514878/104130565-6215ac80-53ac-11eb-9bfe-d76b0b3a7989.png)
