### PR TITLE
Prevent URI encode of custom command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ and if there is more than one parameter use "&" as a separator between them like
 * Added Action "Audio Plugin On/Off/Toggle On Input"
 * Added Stinger 3 and 4 to actions and feedbacks
 * Updated Presets with new feedback's and action.
+* Bugfix: Fixed custom command not working with the new URI encoding.

--- a/src/actions.js
+++ b/src/actions.js
@@ -1315,7 +1315,7 @@ exports.executeAction = function (action) {
 	}
 
 	else if (action.action === 'command') {
-		cmd = `FUNCTION ${opt.command}`;
+		cmd = `FUNCTION ${action.options.command}`;
 	}
 
 	else if (action.action === 'MultiViewOverlay') {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1315,7 +1315,12 @@ exports.executeAction = function (action) {
 	}
 
 	else if (action.action === 'command') {
-		cmd = `FUNCTION ${action.options.command}`;
+		var command = action.options.command.split(' ')[0];
+		var perams = encodeURIComponent(action.options.command.split(' ').splice(1).join(' '));
+
+		console.log(command);
+		console.log(perams);
+		cmd = `FUNCTION ${command} ${perams}`;
 	}
 
 	else if (action.action === 'MultiViewOverlay') {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1317,9 +1317,6 @@ exports.executeAction = function (action) {
 	else if (action.action === 'command') {
 		var command = action.options.command.split(' ')[0];
 		var perams = encodeURIComponent(action.options.command.split(' ').splice(1).join(' '));
-
-		console.log(command);
-		console.log(perams);
 		cmd = `FUNCTION ${command} ${perams}`;
 	}
 


### PR DESCRIPTION
Fixes #94 but partially reopens #51 (only in custom command).
Please note that this will also partially revert changes made by 254d67352b8fec1827b9a91eb4c78b3b28124184.

Values in custom command (i.e. input names) need to be URI-encoded manually by the user.