### PR TITLE
Add Dynamic Inputs and Values support for vMix 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,5 +139,6 @@ and if there is more than one parameter use "&" as a separator between them like
 * Added Feedback "Overlay - Overlay on PGM or PRV"
 * Added Action "Audio Plugin On/Off/Toggle On Input"
 * Added Stinger 3 and 4 to actions and feedbacks
+* Added Action for Dynamic Inputs and Values support
 * Updated Presets with new feedback's and action.
 * Bugfix: Fixed custom command not working with the new URI encoding.

--- a/src/actions.js
+++ b/src/actions.js
@@ -1267,6 +1267,40 @@ exports.getActions = function () {
 				}
 			]
 		},
+		
+		Dynamic: {
+			label: 'Set Dynamic Inputs and Values',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Select Type',
+					id: 'type',
+					default: 'Input',
+					choices: [
+						{ id: 'Input', label: 'Dynamic Input' },
+						{ id: 'Value', label: 'Dynamic Value' }
+					]
+				},
+				{
+					type: 'dropdown',
+					label: 'Select Number',
+					id: 'number',
+					default: '1',
+					choices: [
+						{ id: '1', label: '1' },
+						{ id: '2', label: '2' },
+						{ id: '3', label: '3' },
+						{ id: '4', label: '4' }
+					]
+				},
+				{
+					type: 'textinput',
+					label: 'Value',
+					id: 'value',
+					default: ''
+				}
+			]
+		},
 
 		command: {
 			label: 'Run custom command',
@@ -1426,6 +1460,10 @@ exports.executeAction = function (action) {
 
 	else if (action.action === 'tbar') {
 		cmd = `FUNCTION SetFader value=${opt.fader}`;
+	}
+	
+	else if (action.action === 'Dynamic') {
+		cmd = `FUNCTION SetDynamic${opt.type}${opt.number} Value=${opt.value}`;
 	}
 
 	else {

--- a/src/api.js
+++ b/src/api.js
@@ -166,6 +166,21 @@ exports.parseAPI = function (body) {
 
 				return data;
 			};
+			
+			const dynamicData = dynamic => {
+				const data = [];
+				
+				Object.keys(dynamic).forEach(key => {
+					const matches = key.match(/(input|value)([0-9]+)/i);
+					data.push(dynamic[key] = {
+						type:   matches[1],
+						number: matches[2],
+						value:  dynamic[key][0]
+						});
+				});
+
+				return data;
+			};
 
 			const data = {
 				connected: true,
@@ -205,9 +220,14 @@ exports.parseAPI = function (body) {
 					events: '1',
 					cameraA: '0',
 					cameraB: '0'
-				}
+				},
+				dynamic: xml.vmix.hasOwnProperty('dynamic') ? dynamicData(xml.vmix.dynamic[0]) : []
 			};
-
+			
+			data.dynamic.forEach(dynamic => {
+				this.setVariable(`dynamic_${dynamic.type}_${dynamic.number}`, dynamic.value);
+			});
+			
 			// Update layer tally
 			data.mix.forEach(mix => {
 				const checkTally = (type, input) => {

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,8 @@ class VMixInstance extends instance_skel {
 				events: '1',
 				cameraA: '0',
 				cameraB: '0'
-			}
+			},
+			dynamic: []
 		};
 		this.activatorData = {
 			channelMixer: {},

--- a/src/variables.js
+++ b/src/variables.js
@@ -88,6 +88,14 @@ exports.updateVariableDefinitions = function() {
 			});
 		}
 	});
+	
+	this.data.dynamic.forEach(dynamic => {
+		let typeCapitalized = dynamic.type.charAt(0).toUpperCase() + dynamic.type.slice(1);
+		variables.push({
+			label: `Dynamic ${typeCapitalized} ${dynamic.number} value`,
+			name: `dynamic_${dynamic.type}_${dynamic.number}`
+		});
+	});
 
 	this.setVariableDefinitions(variables);
 };


### PR DESCRIPTION
Add action to support SetDynamicInput# and SetDynamicValue#
Add variables dynamic_input_# and dynamic_value_#

If vMix version does not support Dynamics (i.e. vMix<24), variables are not created.

Variables are future-proof; if more than 4 of them will be added in future vMix releases they will automatically show up in instance (action will still need an update).