### PR TITLE
Add action to support audio channel matrix preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ and if there is more than one parameter use "&" as a separator between them like
 
 **v1.2.17**
 * Added Action "Audio Plugin On/Off/Toggle/Show On Input"
+* Added Action "Channel Matrix Apply Preset"
 * Added Action for Dynamic Inputs and Values support
 * Added Stinger 3 and 4 to actions and feedbacks
 * Added Feedback "Video Call - Video Source"

--- a/src/actions.js
+++ b/src/actions.js
@@ -604,7 +604,7 @@ exports.getActions = function () {
 		},
 		
 		AudioChannelMatrixApplyPreset: {
-			label: 'Audio - Channel Matrix Preset',
+			label: 'Audio - Channel Matrix Apply Preset',
 			options: [
 				input,
 				{

--- a/src/actions.js
+++ b/src/actions.js
@@ -602,6 +602,19 @@ exports.getActions = function () {
 				},			
 			]
 		},
+		
+		AudioChannelMatrixApplyPreset: {
+			label: 'Audio - Channel Matrix Preset',
+			options: [
+				input,
+				{
+					type: 'textinput',
+					label: 'Preset Name',
+					id: 'value',
+					default: ''
+				},			
+			]
+		},
 
 		StartCountdown: {
 			label: 'Title - Start Countdown',


### PR DESCRIPTION
This should close #56

Tested on 24.0.0.50
On v 23 this action is not available (but doesn't cause crashes, it's simply ignored).