### PR TITLE
Fix audio meter calculation for decibels

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,7 +218,7 @@ export const options: Options = {
  * @description Returns dB of a given volume (if the volume of a meter, multiply by 100 first)
  */
 export const volumeTodB = (volume: number): number => {
-  return 20 * Math.log10(volume / 100)
+  return 20 * Math.log10(volume)
 }
 
 /**


### PR DESCRIPTION
vMix audio meter values displayed by Companion are 40 dB too low. On line 221, division by 100 equals -40 dB. vMix gives meter values as amplitude between 0...1, where 1 is full scale (0 dB). https://www.vmix.com/knowledgebase/article.aspx/144/vmix-api-audio-levels 

Function docstring also doesn't make full sense: (if the volume of a meter, multiply by 100 first)