### PR TITLE
fix: issue with input names or titles being 'true' or 'false'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ This module now supports Companions HTTP API, providing endpoints that can be us
 
 
 # Recent Patches
+**v3.6.5**
+- Fixed an issue with `true` or `false` used as input names or title values being parsed as boolean rather than strings
+
 **v3.6.4**
 - Fixed the `Select Index` Preset having the wrong action
 

--- a/docs/PATCH_NOTES.md
+++ b/docs/PATCH_NOTES.md
@@ -1,5 +1,8 @@
 # Patch Notes
 
+**v3.6.5**
+- Fixed an issue with `true` or `false` used as input names or title values being parsed as boolean rather than strings
+
 **v3.6.4**
 - Fixed the `Select Index` Preset having the wrong action
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "studiocoast-vmix",
-	"version": "3.6.4",
+	"version": "3.6.5",
 	"main": "dist/index.js",
 	"scripts": {
 		"dev": "yarn build:watch",

--- a/src/data.ts
+++ b/src/data.ts
@@ -482,8 +482,8 @@ export class VMixData {
             key: input.$.key,
             number: parseInt(input.$.number, 10),
             type: input.$.type,
-            title: input.$.title,
-            shortTitle: input.$.shortTitle || null,
+            title: input.$.title + '',
+            shortTitle: input.$.shortTitle + '' || null,
             state: input.$.state,
             position: input.$.position,
             duration: input.$.duration,
@@ -594,16 +594,16 @@ export class VMixData {
           if (input.$.text) {
             inputData.text = input.$.text.map((text: any) => ({
               index: parseInt(text.$.index, 10),
-              name: text.$.name,
-              value: text._ || '',
+              name: text.$.name + '',
+              value: text._ + '' || '',
             }))
           }
 
           if (input.text && input.text.length > 0) {
             inputData.text = input.text.map((text: any) => ({
               index: parseInt(text.$.index, 10),
-              name: text.$.name,
-              value: text._ || '',
+              name: text.$.name + '',
+              value: text._ + '' || '',
             }))
           }
 


### PR DESCRIPTION
**v3.6.5**
- Fixed an issue with `true` or `false` used as input names or title values being parsed as boolean rather than strings